### PR TITLE
Add window-number

### DIFF
--- a/global.el
+++ b/global.el
@@ -4,6 +4,7 @@
 (require 'rich-minority)
 (require 'smooth-scroll)
 (require 'deft)
+(require 'window-number)
 
 
 ;; Load default auto-complete configs
@@ -107,3 +108,6 @@
       deft-auto-save-interval 0)
 (unless (file-exists-p deft-directory)
   (make-directory deft-directory))
+
+;; Select windows using M- and a number
+(window-number-meta-mode 1)

--- a/packages.el
+++ b/packages.el
@@ -31,6 +31,7 @@
     idle-highlight-mode
     neotree
     deft
+    window-number
 
     ;; Programming
     web-mode


### PR DESCRIPTION
A global minor mode that enables use of the M- and a number to select
windows, use `window-number-mode' to display the window numbers in
the mode-line.
