### PR TITLE
Add shortcut to kill the entire the line cursor is on

### DIFF
--- a/key-bindings.el
+++ b/key-bindings.el
@@ -70,3 +70,6 @@
 ;; Deft
 (global-set-key (kbd "C-x /") 'deft)
 (global-set-key (kbd "C-x m") 'deft-new-file-named)
+
+;; Kill entire line cursor is on
+(global-set-key (kbd "C-S-k") 'kill-whole-line)


### PR DESCRIPTION
`C-S-K` will kill the line the cursor is on wherever the cursor is. No need to `C-a` - `C-k` - `C-k`
